### PR TITLE
Add time entry modal for tickets

### DIFF
--- a/desk/src/components/ticket/TicketTimeEntry.vue
+++ b/desk/src/components/ticket/TicketTimeEntry.vue
@@ -10,14 +10,31 @@
       </div>
       <div class="text-gray-600 text-sm">{{ entry.description }}</div>
     </div>
-    <Button class="mt-4" label="Add Time Entry" @click="$emit('add')" />
+    <Button class="mt-4" label="Add Time Entry" @click="showModal = true" />
+    <TimeEntryModal
+      v-model="showModal"
+      :ticket-id="ticketId"
+      @update="(e) => emitUpdate(e)"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { Button } from "frappe-ui";
+import { ref } from 'vue';
+import { Button } from 'frappe-ui';
+import TimeEntryModal from './TimeEntryModal.vue';
 
-defineProps<{ entries: any[] }>();
+interface Props {
+  entries: any[];
+  ticketId: string;
+}
 
-defineEmits(["add"]);
+const props = defineProps<Props>();
+const emit = defineEmits(['update']);
+
+const showModal = ref(false);
+
+function emitUpdate(e: any[]) {
+  emit('update', e);
+}
 </script>

--- a/desk/src/components/ticket/TimeEntryModal.vue
+++ b/desk/src/components/ticket/TimeEntryModal.vue
@@ -1,0 +1,117 @@
+<template>
+  <Dialog v-model="showDialog" :options="{ title: 'Add Time Entry' }">
+    <template #body-content>
+      <div class="flex flex-col gap-4">
+        <DateTimePicker
+          v-model="form.from_time"
+          label="From Time"
+          class="form-control"
+        />
+        <DateTimePicker
+          v-model="form.to_time"
+          label="To Time"
+          class="form-control"
+        />
+        <FormControl
+          v-model="form.hours"
+          type="number"
+          label="Hours"
+          class="form-control"
+        />
+        <FormControl
+          v-model="form.description"
+          type="textarea"
+          label="Description"
+          class="form-control"
+        />
+        <FormControl
+          v-model="form.billable"
+          type="checkbox"
+          label="Billable"
+          class="form-control"
+        />
+        <FormControl
+          v-if="!form.billable"
+          v-model="form.show_on_invoice"
+          type="checkbox"
+          label="Show on Invoice"
+          class="form-control"
+        />
+      </div>
+    </template>
+    <template #actions>
+      <Button
+        class="w-full"
+        variant="solid"
+        label="Add"
+        :loading="newTimeEntry.loading"
+        @click="handleSubmit"
+      />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue';
+import { Dialog, Button, FormControl, DateTimePicker } from 'frappe-ui';
+import { createToast } from '@/utils';
+import { newTimeEntry, getTimeEntries } from '@/stores/timeEntry';
+
+interface Props {
+  ticketId: string;
+}
+
+const props = defineProps<Props>();
+const showDialog = defineModel<boolean>();
+const emit = defineEmits(['update']);
+
+const form = reactive({
+  from_time: null as string | null,
+  to_time: null as string | null,
+  hours: null as number | null,
+  description: '',
+  billable: true,
+  show_on_invoice: true,
+});
+
+function handleSubmit() {
+  newTimeEntry.submit(
+    {
+      reference_ticket: props.ticketId,
+      from_time: form.from_time,
+      to_time: form.to_time,
+      hours: form.hours,
+      description: form.description,
+      billable: form.billable ? 1 : 0,
+      show_on_invoice: form.show_on_invoice ? 1 : 0,
+    },
+    {
+      validate: (params) => {
+        if (!params.from_time) return 'From Time is required';
+        if (!params.to_time) return 'To Time is required';
+        if (!params.hours) return 'Hours is required';
+      },
+      onSuccess: async () => {
+        createToast({
+          title: 'Time entry added',
+          icon: 'check',
+          iconClasses: 'text-green-600',
+        });
+        const res = await getTimeEntries.update({
+          params: { ticket: props.ticketId },
+        });
+        emit('update', res);
+        showDialog.value = false;
+        form.from_time = null;
+        form.to_time = null;
+        form.hours = null;
+        form.description = '';
+        form.billable = true;
+        form.show_on_invoice = true;
+      },
+    }
+  );
+}
+</script>
+
+<style scoped></style>

--- a/desk/src/components/ticket/index.ts
+++ b/desk/src/components/ticket/index.ts
@@ -1,3 +1,4 @@
 export { default as TicketAgentActivities } from "./TicketAgentActivities.vue";
 export { default as TicketAgentSidebar } from "./TicketAgentSidebar.vue";
 export { default as TicketTimeEntry } from "./TicketTimeEntry.vue";
+export { default as TimeEntryModal } from "./TimeEntryModal.vue";

--- a/desk/src/pages/ticket/MobileTicketAgent.vue
+++ b/desk/src/pages/ticket/MobileTicketAgent.vue
@@ -90,7 +90,8 @@
               <TicketTimeEntry
                 v-else-if="tab.name === 'time'"
                 :entries="ticket.data.time_entries"
-                @add="() => {}"
+                :ticket-id="ticket.data.name"
+                @update="(e) => (ticket.data.time_entries = e)"
               />
               <!-- Rest Activities -->
               <TicketAgentActivities

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -61,7 +61,8 @@
               <TicketTimeEntry
                 v-if="tab.name === 'time'"
                 :entries="ticket.data.time_entries"
-                @add="() => {}"
+                :ticket-id="ticket.data.name"
+                @update="(e) => (ticket.data.time_entries = e)"
               />
               <TicketAgentActivities
                 v-else


### PR DESCRIPTION
## Summary
- add `TimeEntryModal.vue` for entering ticket work hours
- integrate the modal in `TicketTimeEntry.vue`
- update ticket pages to use the new modal
- export modal in ticket components index

## Testing
- `yarn build` *(fails: missing dependencies)*