### PR TITLE
Add time entry as ticket activity

### DIFF
--- a/desk/src/components/TimeEntryBox.vue
+++ b/desk/src/components/TimeEntryBox.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="flex flex-1 flex-col text-base">
+    <div class="mb-1 ml-0.5 flex items-center justify-between">
+      <div class="flex items-center gap-2 text-gray-600">
+        <Avatar
+          size="sm"
+          :label="getUser(owner).full_name"
+          :image="getUser(owner).user_image"
+        />
+        <p>
+          <span class="font-medium text-gray-800">{{ getUser(owner).full_name }}</span>
+          <span> logged </span>
+          <span class="font-medium text-gray-800">{{ hours }}h</span>
+        </p>
+      </div>
+      <Tooltip :text="dateFormat(creation, dateTooltipFormat)">
+        <span class="pl-0.5 text-sm text-gray-600">{{ timeAgo(creation) }}</span>
+      </Tooltip>
+    </div>
+    <div class="rounded bg-gray-50 px-4 py-3">
+      <div class="text-sm text-gray-600">{{ description }}</div>
+      <div class="text-sm text-gray-600">{{ from_time }} - {{ to_time }}</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { TimeEntryActivity } from "@/types";
+import { PropType } from "vue";
+import { Avatar, Tooltip } from "frappe-ui";
+import { dateFormat, timeAgo, dateTooltipFormat } from "@/utils";
+import { useUserStore } from "@/stores/user";
+
+const props = defineProps({
+  activity: {
+    type: Object as PropType<TimeEntryActivity>,
+    required: true,
+  },
+});
+
+const { owner, hours, description, from_time, to_time, creation } = props.activity;
+
+const { getUser } = useUserStore();
+</script>

--- a/desk/src/components/index.ts
+++ b/desk/src/components/index.ts
@@ -27,3 +27,4 @@ export { default as Link } from "./frappe-ui/Link.vue";
 export { default as ListViewBuilder } from "./ListViewBuilder.vue";
 export { default as Section } from "./Section.vue";
 export { default as Icon } from "./Icon.vue";
+export { default as TimeEntryBox } from "./TimeEntryBox.vue";

--- a/desk/src/components/ticket/TicketAgentActivities.vue
+++ b/desk/src/components/ticket/TicketAgentActivities.vue
@@ -23,10 +23,18 @@
               ]"
             >
               <Avatar
-                v-if="activity.type === 'email'"
+                v-if="activity.type === 'email' || activity.type === 'time-entry'"
                 size="md"
-                :label="activity.sender?.full_name"
-                :image="getUser(activity.sender?.name).user_image"
+                :label="
+                  activity.type === 'email'
+                    ? activity.sender?.full_name
+                    : getUser(activity.owner).full_name
+                "
+                :image="
+                  activity.type === 'email'
+                    ? getUser(activity.sender?.name).user_image
+                    : getUser(activity.owner).user_image
+                "
                 class="bg-white"
               />
               <CommentIcon
@@ -51,7 +59,8 @@
               :activity="activity"
               @update="() => emit('update')"
             />
-            <HistoryBox v-else :activity="activity" />
+            <HistoryBox v-else-if="activity.type === 'history'" :activity="activity" />
+            <TimeEntryBox v-else :activity="activity" />
           </div>
         </div>
       </div>
@@ -86,7 +95,7 @@ import {
   EmailIcon,
   ActivityIcon,
 } from "@/components/icons";
-import { EmailArea, CommentBox, HistoryBox } from "@/components";
+import { EmailArea, CommentBox, HistoryBox, TimeEntryBox } from "@/components";
 import { useUserStore } from "@/stores/user";
 import { Avatar } from "frappe-ui";
 import { TicketActivity } from "@/types";

--- a/desk/src/components/ticket/index.ts
+++ b/desk/src/components/ticket/index.ts
@@ -2,3 +2,4 @@ export { default as TicketAgentActivities } from "./TicketAgentActivities.vue";
 export { default as TicketAgentSidebar } from "./TicketAgentSidebar.vue";
 export { default as TicketTimeEntry } from "./TicketTimeEntry.vue";
 export { default as TimeEntryModal } from "./TimeEntryModal.vue";
+export { default as TimeEntryBox } from "../TimeEntryBox.vue";

--- a/desk/src/pages/ticket/MobileTicketAgent.vue
+++ b/desk/src/pages/ticket/MobileTicketAgent.vue
@@ -86,16 +86,7 @@
                 />
               </div>
 
-              <!-- Time Entries -->
-              <TicketTimeEntry
-                v-else-if="tab.name === 'time'"
-                :entries="ticket.data.time_entries"
-                :ticket-id="ticket.data.name"
-                @update="(e) => (ticket.data.time_entries = e)"
-              />
-              <!-- Rest Activities -->
               <TicketAgentActivities
-                v-else
                 ref="ticketAgentActivitiesRef"
                 :activities="filterActivities(tab.name)"
                 :title="tab.label"
@@ -201,7 +192,6 @@ import {
   CommunicationArea,
 } from "@/components";
 import { TicketAgentActivities } from "@/components/ticket";
-import { TicketTimeEntry } from "@/components/ticket";
 import {
   ActivityIcon,
   CommentIcon,
@@ -327,7 +317,7 @@ const tabs: TabObject[] = [
     icon: CommentIcon,
   },
   {
-    name: "time",
+    name: "time-entry",
     label: "Time Entry",
     icon: LucideClock,
   },
@@ -374,7 +364,21 @@ const activities = computed(() => {
     }
   );
 
-  const sorted = [...emailProps, ...commentProps, ...historyProps].sort(
+  const timeEntryProps = ticket.data.time_entries.map((entry) => {
+    return {
+      type: "time-entry",
+      key: entry.creation,
+      creation: entry.creation,
+      owner: entry.owner,
+      hours: entry.hours,
+      description: entry.description,
+      from_time: entry.from_time,
+      to_time: entry.to_time,
+      content: entry.description,
+    };
+  });
+
+  const sorted = [...emailProps, ...commentProps, ...historyProps, ...timeEntryProps].sort(
     (a, b) => new Date(a.creation) - new Date(b.creation)
   );
 
@@ -407,9 +411,6 @@ const activities = computed(() => {
 function filterActivities(eventType: TicketTab) {
   if (eventType === "activity") {
     return activities.value;
-  }
-  if (eventType === "time") {
-    return ticket.data.time_entries || [];
   }
   return activities.value.filter((activity) => activity.type === eventType);
 }

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -58,14 +58,7 @@
           <Tabs v-model="tabIndex" :tabs="tabs">
             <TabList />
             <TabPanel v-slot="{ tab }" class="h-full">
-              <TicketTimeEntry
-                v-if="tab.name === 'time'"
-                :entries="ticket.data.time_entries"
-                :ticket-id="ticket.data.name"
-                @update="(e) => (ticket.data.time_entries = e)"
-              />
               <TicketAgentActivities
-                v-else
                 ref="ticketAgentActivitiesRef"
                 :activities="filterActivities(tab.name)"
                 :title="tab.label"
@@ -170,7 +163,7 @@ import {
   IndicatorIcon,
 } from "@/components/icons";
 import LucideClock from "~icons/lucide/clock";
-import { TicketAgentActivities, TicketAgentSidebar, TicketTimeEntry } from "@/components/ticket";
+import { TicketAgentActivities, TicketAgentSidebar } from "@/components/ticket";
 import { setupCustomizations } from "@/composables/formCustomisation";
 import { useView } from "@/composables/useView";
 import { socket } from "@/socket";
@@ -313,7 +306,7 @@ const tabs: TabObject[] = [
     icon: CommentIcon,
   },
   {
-    name: "time",
+    name: "time-entry",
     label: "Time Entry",
     icon: LucideClock,
   },
@@ -362,7 +355,21 @@ const activities = computed(() => {
     }
   );
 
-  const sorted = [...emailProps, ...commentProps, ...historyProps].sort(
+  const timeEntryProps = ticket.data.time_entries.map((entry) => {
+    return {
+      type: "time-entry",
+      key: entry.creation,
+      creation: entry.creation,
+      owner: entry.owner,
+      hours: entry.hours,
+      description: entry.description,
+      from_time: entry.from_time,
+      to_time: entry.to_time,
+      content: entry.description,
+    };
+  });
+
+  const sorted = [...emailProps, ...commentProps, ...historyProps, ...timeEntryProps].sort(
     (a, b) => new Date(a.creation) - new Date(b.creation)
   );
 
@@ -394,9 +401,6 @@ const activities = computed(() => {
 function filterActivities(eventType: TicketTab) {
   if (eventType === "activity") {
     return activities.value;
-  }
-  if (eventType === "time") {
-    return ticket.data.time_entries || [];
   }
   return activities.value.filter((activity) => activity.type === eventType);
 }

--- a/desk/src/types.ts
+++ b/desk/src/types.ts
@@ -215,7 +215,12 @@ export interface EmailAccount {
   default_incoming?: boolean;
 }
 
-export type TicketTab = "activity" | "email" | "comment" | "details";
+export type TicketTab =
+  | "activity"
+  | "email"
+  | "comment"
+  | "details"
+  | "time-entry";
 
 export interface TabObject {
   name: TicketTab;
@@ -330,7 +335,20 @@ export interface CommentActivity extends BaseActivity {
   attachments: FileAttachment[];
 }
 
-export type TicketActivity = HistoryActivity | EmailActivity | CommentActivity;
+export interface TimeEntryActivity extends BaseActivity {
+  type: "time-entry";
+  owner: string;
+  hours: number;
+  description: string;
+  from_time: string;
+  to_time: string;
+}
+
+export type TicketActivity =
+  | HistoryActivity
+  | EmailActivity
+  | CommentActivity
+  | TimeEntryActivity;
 
 interface FileAttachment {
   name: string;


### PR DESCRIPTION
## Summary
- add `time-entry` option to `TicketTab` and add `TimeEntryActivity`
- show time-entry items in ticket activity feed
- display time entry details via new `TimeEntryBox` component

## Testing
- `pre-commit` *(fails: command not found)*