### PR TITLE
Add sidebar timer for quick time entry

### DIFF
--- a/desk/src/components/ticket/SidebarTimer.vue
+++ b/desk/src/components/ticket/SidebarTimer.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="flex flex-col gap-2 border-t p-4">
+    <div class="flex items-center justify-between">
+      <span class="text-sm font-medium text-gray-700">{{ formatted }}</span>
+      <Button size="sm" :label="running ? 'Stop' : 'Start'" @click="toggle" />
+    </div>
+    <Button
+      size="sm"
+      class="w-full"
+      label="Save"
+      variant="solid"
+      :disabled="!hasDuration"
+      @click="openModal"
+    />
+    <TimeEntryModal
+      v-model="showModal"
+      :ticket-id="ticketId"
+      :default-from-time="fromTime"
+      :default-to-time="toTime"
+      :default-hours="hours"
+      @update="(e) => emit('update', e)"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { Button } from 'frappe-ui';
+import TimeEntryModal from './TimeEntryModal.vue';
+import { dayjs } from '@/dayjs';
+
+interface Props {
+  ticketId: string;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits(['update']);
+
+const running = ref(false);
+const start = ref<any>(null);
+const end = ref<any>(null);
+let interval: any = null;
+const elapsed = ref(0);
+const showModal = ref(false);
+
+function toggle() {
+  if (!running.value) {
+    running.value = true;
+    start.value = dayjs();
+    elapsed.value = 0;
+    interval = setInterval(() => {
+      elapsed.value = dayjs().diff(start.value, 'second');
+    }, 1000);
+  } else {
+    running.value = false;
+    end.value = dayjs();
+    clearInterval(interval);
+    elapsed.value = end.value.diff(start.value, 'second');
+  }
+}
+
+function openModal() {
+  if (running.value) {
+    toggle();
+  }
+  if (!start.value) return;
+  showModal.value = true;
+}
+
+const formatted = computed(() => {
+  const h = Math.floor(elapsed.value / 3600)
+    .toString()
+    .padStart(2, '0');
+  const m = Math.floor((elapsed.value % 3600) / 60)
+    .toString()
+    .padStart(2, '0');
+  const s = Math.floor(elapsed.value % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${h}:${m}:${s}`;
+});
+
+const hasDuration = computed(() => elapsed.value > 0);
+
+const hours = computed(() => {
+  return elapsed.value ? parseFloat((elapsed.value / 3600).toFixed(2)) : null;
+});
+
+const fromTime = computed(() => (start.value ? start.value.format() : null));
+const toTime = computed(() => {
+  if (running.value) {
+    return dayjs().format();
+  }
+  return end.value ? end.value.format() : null;
+});
+</script>
+
+<style scoped></style>

--- a/desk/src/components/ticket/TicketAgentSidebar.vue
+++ b/desk/src/components/ticket/TicketAgentSidebar.vue
@@ -36,6 +36,7 @@
     <TicketAgentDetails :ticket="ticket" />
     <!-- fields -->
     <TicketAgentFields :ticket="ticket" @update="update" />
+    <SidebarTimer :ticket-id="ticket.name" />
     <TicketMergeModal
       :ticket="ticket"
       v-if="showMergeModal"
@@ -51,6 +52,7 @@ import TicketAgentDetails from "./TicketAgentDetails.vue";
 import TicketAgentContact from "./TicketAgentContact.vue";
 import TicketAgentFields from "./TicketAgentFields.vue";
 import TicketMergeModal from "./TicketMergeModal.vue";
+import SidebarTimer from "./SidebarTimer.vue";
 import LucideMerge from "~icons/lucide/merge";
 import { copyToClipboard } from "@/utils";
 import { Ticket } from "@/types";

--- a/desk/src/components/ticket/TimeEntryModal.vue
+++ b/desk/src/components/ticket/TimeEntryModal.vue
@@ -52,16 +52,23 @@
 </template>
 
 <script setup lang="ts">
-import { reactive } from 'vue';
+import { reactive, watch } from 'vue';
 import { Dialog, Button, FormControl, DateTimePicker } from 'frappe-ui';
 import { createToast } from '@/utils';
 import { newTimeEntry, getTimeEntries } from '@/stores/timeEntry';
 
 interface Props {
   ticketId: string;
+  defaultFromTime?: string | null;
+  defaultToTime?: string | null;
+  defaultHours?: number | null;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  defaultFromTime: null,
+  defaultToTime: null,
+  defaultHours: null,
+});
 const showDialog = defineModel<boolean>();
 const emit = defineEmits(['update']);
 
@@ -73,6 +80,17 @@ const form = reactive({
   billable: true,
   show_on_invoice: true,
 });
+
+watch(
+  () => showDialog.value,
+  (val) => {
+    if (val) {
+      form.from_time = props.defaultFromTime;
+      form.to_time = props.defaultToTime;
+      form.hours = props.defaultHours;
+    }
+  }
+);
 
 function handleSubmit() {
   newTimeEntry.submit(

--- a/desk/src/components/ticket/index.ts
+++ b/desk/src/components/ticket/index.ts
@@ -2,3 +2,4 @@ export { default as TicketAgentActivities } from "./TicketAgentActivities.vue";
 export { default as TicketAgentSidebar } from "./TicketAgentSidebar.vue";
 export { default as TicketTimeEntry } from "./TicketTimeEntry.vue";
 export { default as TimeEntryModal } from "./TimeEntryModal.vue";
+export { default as SidebarTimer } from "./SidebarTimer.vue";


### PR DESCRIPTION
## Summary
- add a SidebarTimer component
- allow TimeEntryModal to accept default time values
- mount SidebarTimer in TicketAgentSidebar
- re-export SidebarTimer from ticket components

## Testing
- `yarn lint` *(fails: command not found)*
- `yarn test` *(fails: command not found)*