### PR TITLE
Add sidebar timer component

### DIFF
--- a/desk/src/components/ticket/SidebarTimer.vue
+++ b/desk/src/components/ticket/SidebarTimer.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="flex items-center justify-between gap-2 border-t p-4">
+    <span class="font-mono text-sm">{{ formattedDuration }}</span>
+    <div class="flex items-center gap-1">
+      <Button
+        v-if="timerState === 'idle' || timerState === 'paused'"
+        variant="ghost"
+        @click="start"
+      >
+        <template #icon>
+          <IconPlay class="h-4 w-4" />
+        </template>
+      </Button>
+      <template v-else>
+        <Button variant="ghost" @click="pause">
+          <template #icon>
+            <IconPause class="h-4 w-4" />
+          </template>
+        </Button>
+        <Button variant="ghost" @click="stop">
+          <template #icon>
+            <IconStop class="h-4 w-4" />
+          </template>
+        </Button>
+      </template>
+      <Button variant="ghost" :disabled="duration === 0" @click="save">
+        <template #icon>
+          <IconSave class="h-4 w-4" />
+        </template>
+      </Button>
+    </div>
+    <TimeEntryModal
+      v-model="showModal"
+      :ticket-id="ticketId"
+      :initial-hours="Number((duration / 3600).toFixed(2))"
+      @update="(e) => emit('update', e)"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onUnmounted } from "vue";
+import { Button } from "frappe-ui";
+import IconPlay from "~icons/lucide/play";
+import IconPause from "~icons/lucide/pause";
+import IconStop from "~icons/lucide/stop-circle";
+import IconSave from "~icons/lucide/save";
+import TimeEntryModal from "./TimeEntryModal.vue";
+import { formatTime } from "@/utils";
+
+interface Props {
+  ticketId: string;
+}
+const props = defineProps<Props>();
+const emit = defineEmits(["update"]);
+
+const timerState = ref<"idle" | "running" | "paused">("idle");
+const duration = ref(0);
+let intervalId: number | null = null;
+
+const showModal = ref(false);
+
+watch(timerState, (state) => {
+  if (state === "running") {
+    intervalId = window.setInterval(() => {
+      duration.value++;
+    }, 1000);
+  } else if (intervalId !== null) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+});
+
+function start() {
+  if (timerState.value !== "running") {
+    timerState.value = "running";
+  }
+}
+
+function pause() {
+  if (timerState.value === "running") {
+    timerState.value = "paused";
+  }
+}
+
+function stop() {
+  timerState.value = "idle";
+}
+
+function save() {
+  stop();
+  showModal.value = true;
+}
+
+const formattedDuration = computed(() => formatTime(duration.value));
+
+watch(showModal, (val) => {
+  if (!val && timerState.value === "idle") {
+    duration.value = 0;
+  }
+});
+
+onUnmounted(() => {
+  if (intervalId !== null) {
+    clearInterval(intervalId);
+  }
+});
+</script>
+
+<style scoped></style>

--- a/desk/src/components/ticket/TimeEntryModal.vue
+++ b/desk/src/components/ticket/TimeEntryModal.vue
@@ -52,26 +52,33 @@
 </template>
 
 <script setup lang="ts">
-import { reactive } from 'vue';
-import { Dialog, Button, FormControl, DateTimePicker } from 'frappe-ui';
-import { createToast } from '@/utils';
-import { newTimeEntry, getTimeEntries } from '@/stores/timeEntry';
+import { reactive, watch } from "vue";
+import { Dialog, Button, FormControl, DateTimePicker } from "frappe-ui";
+import { createToast } from "@/utils";
+import { newTimeEntry, getTimeEntries } from "@/stores/timeEntry";
 
 interface Props {
   ticketId: string;
+  initialHours?: number | null;
 }
 
 const props = defineProps<Props>();
 const showDialog = defineModel<boolean>();
-const emit = defineEmits(['update']);
+const emit = defineEmits(["update"]);
 
 const form = reactive({
   from_time: null as string | null,
   to_time: null as string | null,
   hours: null as number | null,
-  description: '',
+  description: "",
   billable: true,
   show_on_invoice: true,
+});
+
+watch(showDialog, (val) => {
+  if (val && props.initialHours != null) {
+    form.hours = props.initialHours;
+  }
 });
 
 function handleSubmit() {
@@ -87,29 +94,29 @@ function handleSubmit() {
     },
     {
       validate: (params) => {
-        if (!params.from_time) return 'From Time is required';
-        if (!params.to_time) return 'To Time is required';
-        if (!params.hours) return 'Hours is required';
+        if (!params.from_time) return "From Time is required";
+        if (!params.to_time) return "To Time is required";
+        if (!params.hours) return "Hours is required";
       },
       onSuccess: async () => {
         createToast({
-          title: 'Time entry added',
-          icon: 'check',
-          iconClasses: 'text-green-600',
+          title: "Time entry added",
+          icon: "check",
+          iconClasses: "text-green-600",
         });
         const res = await getTimeEntries.update({
           params: { ticket: props.ticketId },
         });
-        emit('update', res);
+        emit("update", res);
         showDialog.value = false;
         form.from_time = null;
         form.to_time = null;
         form.hours = null;
-        form.description = '';
+        form.description = "";
         form.billable = true;
         form.show_on_invoice = true;
       },
-    }
+    },
   );
 }
 </script>

--- a/desk/src/components/ticket/index.ts
+++ b/desk/src/components/ticket/index.ts
@@ -3,3 +3,4 @@ export { default as TicketAgentSidebar } from "./TicketAgentSidebar.vue";
 export { default as TicketTimeEntry } from "./TicketTimeEntry.vue";
 export { default as TimeEntryModal } from "./TimeEntryModal.vue";
 export { default as TimeEntryBox } from "../TimeEntryBox.vue";
+export { default as SidebarTimer } from "./SidebarTimer.vue";


### PR DESCRIPTION
## Summary
- implement SidebarTimer with lucide icons
- allow TimeEntryModal to accept initial hours
- export SidebarTimer in ticket components index
- refactor timer logic with lifecycle cleanup

## Testing
- `npx prettier -w desk/src/components/ticket/SidebarTimer.vue desk/src/components/ticket/TimeEntryModal.vue desk/src/components/ticket/index.ts`
- `pre-commit run --files desk/src/components/ticket/SidebarTimer.vue desk/src/components/ticket/TimeEntryModal.vue desk/src/components/ticket/index.ts` *(fails: command not found)*