### PR TITLE
Fix time-entry submission and unify date format

### DIFF
--- a/desk/src/stores/timeEntry.ts
+++ b/desk/src/stores/timeEntry.ts
@@ -2,6 +2,11 @@ import { createResource } from "frappe-ui";
 
 export const newTimeEntry = createResource({
   url: "helpdesk.helpdesk.doctype.hd_ticket.api.new_time_entry",
+  makeParams(values) {
+    return {
+      doc: values,
+    };
+  },
 });
 
 export const getTimeEntries = createResource({

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -56,7 +56,7 @@ export function validateEmailWithZod(email: string) {
 }
 
 export function dateFormat(date, format) {
-  const _format = format || "DD-MM-YYYY HH:mm:ss";
+  const _format = format || "DD.MM.YYYY HH:mm:ss";
   return useDateFormat(date, _format).value;
 }
 


### PR DESCRIPTION
## Summary
- ensure TimeEntry API gets `doc` payload
- format dates as `DD.MM.YYYY HH:mm:ss` by default

## Testing
- `pre-commit` *(fails: command not found)*